### PR TITLE
docker-compose: Workaround docker not resolving dapr path correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       "--resources-path", "./components"
     ]
     volumes:
-      - "./components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
+      - "./../template-microservice/components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
     depends_on:
       - app-template
       - redis


### PR DESCRIPTION
Quick workaround because docker does not resolve paths correctly when using its feature to merge multiple compose files