### PR TITLE
Docker: Improve build caching and fix network mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:experimental
-FROM eclipse-temurin:17-jdk AS build
+FROM gradle:7.6.2-jdk17 AS build
 WORKDIR /workspace/app
 
 COPY . /workspace/app
-RUN ./gradlew clean build -x test
+RUN gradle clean build -x test
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHOT.jar)
 
 FROM eclipse-temurin:17-jdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@
 FROM gradle:7.6.2-jdk17 AS build
 WORKDIR /workspace/app
 
+# Copy only gradle files to container so we can install them
+COPY ./build.gradle ./settings.gradle /workspace/app/
+
+# install dependencies. This will be cached by the docker layered cache. This command will fail because the
+# app code is still missing, so we return 0 so docker thinks the command executed successfully (but the
+# dependencies are still downloaded even if the command fails so now we have them cached)
+RUN gradle clean build -x test || return 0
+
+# Now copy the actual app code and build it
 COPY . /workspace/app
 RUN gradle clean build -x test
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHOT.jar)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   database-template:
     image: postgres:alpine
     restart: always
-    network_mode: bridge
     expose:
       - 1032
     ports:


### PR DESCRIPTION
* Reduces build times by fetching java build dependencies in a separate step which means they can be cached between re-builds
* Removes the network-mode: bridge property in the docker compose. Otherwise The app cannot connect to the db container